### PR TITLE
feat: implement user login endpoint

### DIFF
--- a/src/db/migrations/0001_aromatic_beyonder.sql
+++ b/src/db/migrations/0001_aromatic_beyonder.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `sessions` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`token` varchar(255) NOT NULL,
+	`user_id` int NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `sessions_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+ALTER TABLE `sessions` ADD CONSTRAINT `sessions_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE no action ON UPDATE no action;

--- a/src/db/migrations/meta/0001_snapshot.json
+++ b/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,138 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "c5b064c1-07d9-4e71-a587-8ee515b71e0d",
+  "prevId": "0c1a6c3e-0742-4e87-b9f4-3846f98f5047",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776770920056,
       "tag": "0000_abnormal_doctor_doom",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1776823702671,
+      "tag": "0001_aromatic_beyonder",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,3 +10,15 @@ export const users = mysqlTable("users", {
 
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
+
+export const sessions = mysqlTable("sessions", {
+  id: int("id").primaryKey().autoincrement(),
+  token: varchar("token", { length: 255 }).notNull(),
+  userId: int("user_id")
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type Session = typeof sessions.$inferSelect;
+export type NewSession = typeof sessions.$inferInsert;

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -1,5 +1,10 @@
 import { Elysia, t } from "elysia";
-import { registerUser, EmailAlreadyExistsError } from "../services/users-service";
+import {
+  registerUser,
+  EmailAlreadyExistsError,
+  loginUser,
+  InvalidCredentialsError,
+} from "../services/users-service";
 
 export const usersRoute = new Elysia({ prefix: "/users" })
   .post(
@@ -18,6 +23,26 @@ export const usersRoute = new Elysia({ prefix: "/users" })
     {
       body: t.Object({
         name: t.String({ minLength: 1 }),
+        email: t.String({ format: "email" }),
+        password: t.String({ minLength: 1 }),
+      }),
+    }
+  )
+  .post(
+    "/login",
+    async ({ body, set }) => {
+      try {
+        return await loginUser(body);
+      } catch (err) {
+        if (err instanceof InvalidCredentialsError) {
+          set.status = 401;
+          return { error: err.message };
+        }
+        throw err;
+      }
+    },
+    {
+      body: t.Object({
         email: t.String({ format: "email" }),
         password: t.String({ minLength: 1 }),
       }),

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,11 +1,17 @@
 import bcrypt from "bcryptjs";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
-import { users } from "../db/schema";
+import { users, sessions } from "../db/schema";
 
 export class EmailAlreadyExistsError extends Error {
   constructor() {
     super("Email sudah terdaftar");
+  }
+}
+
+export class InvalidCredentialsError extends Error {
+  constructor() {
+    super("email atau password salah");
   }
 }
 
@@ -32,4 +38,26 @@ export async function registerUser(input: {
   });
 
   return { data: "ok" };
+}
+
+export async function loginUser(input: { email: string; password: string }) {
+  const [user] = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, input.email));
+
+  if (!user) {
+    throw new InvalidCredentialsError();
+  }
+
+  const passwordMatch = await bcrypt.compare(input.password, user.password);
+  if (!passwordMatch) {
+    throw new InvalidCredentialsError();
+  }
+
+  const token = crypto.randomUUID();
+
+  await db.insert(sessions).values({ token, userId: user.id });
+
+  return { data: token };
 }


### PR DESCRIPTION
## Summary

- Add `sessions` table (schema + migration) with FK to `users`
- Add `loginUser` service with bcrypt password verification and UUID token generation
- Add `POST /api/users/login` endpoint

## Closes

Closes #4

## Test plan

- [ ] `POST /api/users/login` dengan kredensial valid → HTTP 200, response `{"data":"<uuid>"}`
- [ ] `POST /api/users/login` dengan password salah → HTTP 401, response `{"error":"email atau password salah"}`
- [ ] `POST /api/users/login` dengan email tidak terdaftar → HTTP 401, response `{"error":"email atau password salah"}`
- [ ] Tabel `sessions` memiliki row baru setiap login sukses

🤖 Generated with [Claude Code](https://claude.com/claude-code)